### PR TITLE
Fixing #6: toConstantCase

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,23 @@ Inflector.parameterize('Donald E. Knuth', { separator: '+' })  // => 'donald+e+k
 ```
 
 
+### Inflector.constantify
+
+```js
+string constantify(string words)
+```
+
+Converts words (camelCased, under_scored, or dasherized) to CONSTANT_CASE.
+
+```js
+Inflector.constantify('bankAccount')   // => 'BANK_ACCOUNT'
+Inflector.constantify('bank-account')  // => 'BANK_ACCOUNT'
+Inflector.constantify('bank_account')  // => 'BANK_ACCOUNT'
+Inflector.constantify('Bank Account')  // => 'BANK_ACCOUNT'
+```
+
+
+
 ## Contributing
 
 Here's a quick guide:

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "ordinalize",
     "parameterize",
     "transliterate",
-    "activesupport"
+    "activesupport",
+    "constantcase"
   ],
   "scripts": {
     "lint": "eslint --max-warnings 0 src/**",

--- a/src/constantify.js
+++ b/src/constantify.js
@@ -1,0 +1,5 @@
+import underscore from "./underscore";
+
+export default function toConstantCase(word) {
+  return underscore(word).toUpperCase().replace(/\s+/g, "_");
+}

--- a/src/index.js
+++ b/src/index.js
@@ -15,3 +15,4 @@ export { default as parameterize } from "./parameterize";
 export { default as capitalize } from "./capitalize";
 export { default as inflections } from "./inflections";
 export { default as transliterations } from "./transliterations";
+export { default as constantify } from "./constantify";

--- a/test/cases.js
+++ b/test/cases.js
@@ -302,5 +302,16 @@ module.exports = {
     'cow'    : 'kine',
     'zombie' : 'zombies',
     'genus'  : 'genera'
-  }
+  },
+
+  WordsToConstantCase: {
+    'Conciliation'  : 'CONCILIATION',
+    'conciliation'  : 'CONCILIATION',
+    'bankAccount'   : 'BANK_ACCOUNT',
+    'BankAccount'   : 'BANK_ACCOUNT',
+    'bank-account'  : 'BANK_ACCOUNT',
+    'bank_account'  : 'BANK_ACCOUNT',
+    'Bank Account'  : 'BANK_ACCOUNT',
+    'Multiple   Bank Account'  : 'MULTIPLE_BANK_ACCOUNT'
+  },
 };

--- a/test/index.js
+++ b/test/index.js
@@ -430,4 +430,10 @@ describe('Inflector', () => {
     assert.equal(Inflector.parameterize('Mädchen'), 'madchen');
     assert.equal(Inflector.parameterize('Mädchen', { locale: 'de' }), 'maedchen');
   });
+
+  it('properly converts words to constant case', () => {
+    objEach(TestCases.WordsToConstantCase, function(words, constantCase) {
+      assert.equal(Inflector.constantify(words), constantCase);
+    });
+  });
 });


### PR DESCRIPTION
Fixing #6: Adding toConstantCase method to convert a word into an uppercase only letters with words separated with underscores.