### PR TITLE
Add preserveCase option to parameterize

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,12 @@ Inflector.parameterize('Donald E. Knuth')                      // => 'donald-e-k
 Inflector.parameterize('Donald E. Knuth', { separator: '+' })  // => 'donald+e+knuth'
 ```
 
+As of v2.1, there's also a `preserveCase` option:
+
+```js
+Inflector.parameterize('Donald E. Knuth', { preserveCase: true })  // => 'Donald+E+Knuth'
+```
+
 
 ### Inflector.constantify
 

--- a/src/parameterize.js
+++ b/src/parameterize.js
@@ -33,5 +33,9 @@ export default function parameterize(string, options = {}) {
     );
   }
 
+  if (options.preserveCase) {
+    return result;
+  }
+
   return result.toLowerCase();
 }

--- a/test/cases.js
+++ b/test/cases.js
@@ -171,6 +171,17 @@ module.exports = {
     'Test with malformed utf8 \251'       : 'testwithmalformedutf8'
   },
 
+  StringToParameterizeWithPreserveCase: {
+    'Donald E. Knuth': 'Donald-E-Knuth',
+    'Random text with *(bad)* Characters': 'Random-text-with-bad-Characters',
+    'Allow_Under_Scores': 'Allow_Under_Scores',
+    'Trailing BAD characters!@#': 'Trailing-BAD-characters',
+    '!@#leading bad Characters': 'leading-bad-Characters',
+    'squeeze   Separators': 'squeeze-Separators',
+    'Test with + Sign': 'Test-with-Sign',
+    'Test with malformed UTF8 \251': 'Test-with-malformed-UTF8'
+  },
+
   StringToParameterizeWithUnderscore: {
     'Donald E. Knuth'                     : 'donald_e_knuth',
     'Random text with *(bad)* characters' : 'random_text_with_bad_characters',

--- a/test/index.js
+++ b/test/index.js
@@ -403,6 +403,12 @@ describe('Inflector', () => {
     });
   });
 
+  it('properly parameterizes with preserve-case option', () => {
+    objEach(TestCases.StringToParameterizeWithPreserveCase, function(someString, parameterizedString) {
+      assert.equal(Inflector.parameterize(someString, { preserveCase: true }), parameterizedString);
+    });
+  });
+
   it('properly parameterizes with multi character separator', () => {
     objEach(TestCases.StringToParameterized, function(someString, parameterizedString) {
       assert.equal(Inflector.parameterize(someString, { separator: '__sep__' }), parameterizedString.replace(/-/g, '__sep__'));


### PR DESCRIPTION
```js
parameterize('Donald E. Knuth') //=> 'donald-e-knuth
parameterize('Donald E. Knuth', { preserveCase: true }) //=> 'Donald-E-Knuth'
```